### PR TITLE
Fix rspfile value to be computed with target variables

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaActionsHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaActionsHelper.java
@@ -133,9 +133,12 @@ public class NinjaActionsHelper {
 
     NinjaScope targetScope = createTargetScope(target);
     int targetOffset = target.getOffset();
-    maybeCreateRspFile(rule, targetScope, targetOffset, inputsBuilder);
 
-    String command = resolveRuleCommand(targetScope, targetOffset, rule);
+    ImmutableSortedMap<String, List<Pair<Integer, String>>> map =
+        resolveRuleVariables(targetScope, targetOffset, rule);
+    String command = map.get(NinjaRuleVariable.COMMAND.lowerCaseName()).get(0).getSecond();
+    maybeCreateRspFile(rule, inputsBuilder, map);
+
     if (!artifactsHelper.getWorkingDirectory().isEmpty()) {
       command = String.format("cd %s && ", artifactsHelper.getWorkingDirectory()) + command;
     }
@@ -180,23 +183,26 @@ public class NinjaActionsHelper {
 
   private void maybeCreateRspFile(
       NinjaRule rule,
-      NinjaScope targetScope,
-      int targetOffset,
-      NestedSetBuilder<Artifact> inputsBuilder)
+      NestedSetBuilder<Artifact> inputsBuilder,
+      ImmutableSortedMap<String, List<Pair<Integer, String>>> ruleVariables)
       throws GenericParsingException {
-    NinjaVariableValue value = rule.getVariables().get(NinjaRuleVariable.RSPFILE);
-    NinjaVariableValue content = rule.getVariables().get(NinjaRuleVariable.RSPFILE_CONTENT);
-    if (value == null && content == null) {
+    List<Pair<Integer, String>> filePair =
+        ruleVariables.get(NinjaRuleVariable.RSPFILE.lowerCaseName());
+    List<Pair<Integer, String>> contentPair =
+        ruleVariables.get(NinjaRuleVariable.RSPFILE_CONTENT.lowerCaseName());
+
+    if (filePair == null && contentPair == null) {
       return;
     }
-    if (value == null || content == null) {
+    if (filePair == null || contentPair == null) {
       ruleContext.ruleError(
           String.format(
               "Both rspfile and rspfile_content should be defined for rule '%s'.", rule.getName()));
       return;
     }
-    String fileName = targetScope.getExpandedValue(targetOffset, value);
-    String contentString = targetScope.getExpandedValue(targetOffset, content);
+
+    String fileName = filePair.get(0).getSecond();
+    String contentString = contentPair.get(0).getSecond();
     if (!fileName.trim().isEmpty()) {
       DerivedArtifact rspArtifact =
           artifactsHelper.createOutputArtifact(PathFragment.create(fileName));
@@ -219,7 +225,7 @@ public class NinjaActionsHelper {
    *
    * <p>See {@link NinjaRuleVariable} for the list.
    */
-  private static String resolveRuleCommand(
+  private static ImmutableSortedMap<String, List<Pair<Integer, String>>> resolveRuleVariables(
       NinjaScope targetScope, int targetOffset, NinjaRule rule) {
     ImmutableSortedMap.Builder<String, List<Pair<Integer, String>>> builder =
         ImmutableSortedMap.naturalOrder();
@@ -233,8 +239,11 @@ public class NinjaActionsHelper {
       builder.put(Ascii.toLowerCase(type.name()), ImmutableList.of(Pair.of(0, expandedValue)));
     }
     NinjaScope expandedRuleScope = targetScope.createScopeFromExpandedValues(builder.build());
-    return expandedRuleScope.getExpandedValue(
-        targetOffset, rule.getVariables().get(NinjaRuleVariable.COMMAND));
+    String command =
+        expandedRuleScope.getExpandedValue(
+            targetOffset, rule.getVariables().get(NinjaRuleVariable.COMMAND));
+    builder.put(NinjaRuleVariable.COMMAND.lowerCaseName(), ImmutableList.of(Pair.of(0, command)));
+    return builder.build();
   }
 
   private NinjaScope createTargetScope(NinjaTarget target) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaRuleVariable.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaRuleVariable.java
@@ -31,6 +31,10 @@ public enum NinjaRuleVariable {
   RSPFILE_CONTENT,
   POOL;
 
+  public String lowerCaseName() {
+    return Ascii.toLowerCase(name());
+  }
+
   public static NinjaRuleVariable nullOrValue(String name) {
     try {
       return valueOf(Ascii.toUpperCase(name));


### PR DESCRIPTION
Support the case when rspfile = ${out}.rsp, and
rspfile_content = ${in}

Closes #10847.

PiperOrigin-RevId: 296836037