### PR TITLE
Run SkyframeTests on highcpu RBE workers as they've been flaky recently.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -72,6 +72,7 @@ java_test(
             exclude = ["MacOSXFsEventsDiffAwarenessTest.java"] + CROSS_PLATFORM_WINDOWS_TESTS,
         ),
     }),
+    exec_compatible_with = ["//:highcpu_machine"],
     shard_count = 20,
     tags = ["skyframe"],
     test_class = "com.google.devtools.build.lib.AllTests",


### PR DESCRIPTION
They're not flaky on other platforms, so I suspect that they simply need a bit more CPU power.

RELNOTES: None.
PiperOrigin-RevId: 297312684