### PR TITLE
Treat timeouts expanding NestedSet as lost inputs.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/collect/nestedset/NestedSetExpander.java
+++ b/src/main/java/com/google/devtools/build/lib/collect/nestedset/NestedSetExpander.java
@@ -14,17 +14,18 @@
 package com.google.devtools.build.lib.collect.nestedset;
 
 import com.google.common.collect.ImmutableList;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Helper class to expand {@link NestedSet} instances.
  *
- * <p>Implementations besides {@link NO_CALLBACKS} may wish to implement callbacks or timeouts for
+ * <p>Implementations besides {@link #DEFAULT} may wish to implement callbacks or timeouts for
  * dealing with expansions of sets from storage.
  */
 public interface NestedSetExpander {
 
   <T> ImmutableList<? extends T> toListInterruptibly(NestedSet<? extends T> nestedSet)
-      throws InterruptedException;
+      throws InterruptedException, TimeoutException;
 
   /** Simply delegates to {@link NestedSet#toListInterruptibly} without doing anything special. */
   NestedSetExpander DEFAULT = NestedSet::toListInterruptibly;

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutor.java
@@ -38,7 +38,6 @@ import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
-import com.google.devtools.build.lib.collect.nestedset.NestedSetExpander;
 import com.google.devtools.build.lib.concurrent.Uninterruptibles;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
@@ -191,8 +190,7 @@ public final class SequencedSkyframeExecutor extends SkyframeExecutor {
         mutableArtifactFactorySupplier,
         new ConfiguredTargetProgressReceiver(),
         /*nonexistentFileReceiver=*/ null,
-        managedDirectoriesKnowledge,
-        NestedSetExpander.DEFAULT);
+        managedDirectoriesKnowledge);
     this.diffAwarenessManager = new DiffAwarenessManager(diffAwarenessFactories);
     this.customDirtinessCheckers = customDirtinessCheckers;
     this.managedDirectoriesKnowledge = managedDirectoriesKnowledge;

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -225,19 +225,17 @@ public final class SkyframeActionExecutor {
 
   private boolean bazelRemoteExecutionEnabled;
 
-  private final NestedSetExpander nestedSetExpander;
+  private NestedSetExpander nestedSetExpander;
 
   SkyframeActionExecutor(
       ActionKeyContext actionKeyContext,
       AtomicReference<ActionExecutionStatusReporter> statusReporterRef,
       Supplier<ImmutableList<Root>> sourceRootSupplier,
-      Function<PathFragment, SourceArtifact> sourceArtifactFactory,
-      NestedSetExpander nestedSetExpander) {
+      Function<PathFragment, SourceArtifact> sourceArtifactFactory) {
     this.actionKeyContext = actionKeyContext;
     this.statusReporterRef = statusReporterRef;
     this.sourceRootSupplier = sourceRootSupplier;
     this.sourceArtifactFactory = sourceArtifactFactory;
-    this.nestedSetExpander = nestedSetExpander;
   }
 
   /**
@@ -924,9 +922,13 @@ public final class SkyframeActionExecutor {
     return hadExecutionError && !options.getOptions(KeepGoingOption.class).keepGoing;
   }
 
-  void configure(MetadataProvider fileCache, ActionInputPrefetcher actionInputPrefetcher) {
+  public void configure(
+      MetadataProvider fileCache,
+      ActionInputPrefetcher actionInputPrefetcher,
+      NestedSetExpander nestedSetExpander) {
     this.perBuildFileCache = fileCache;
     this.actionInputPrefetcher = actionInputPrefetcher;
+    this.nestedSetExpander = nestedSetExpander;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -296,7 +296,7 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
 
   private final AtomicReference<ActionExecutionStatusReporter> statusReporterRef =
       new AtomicReference<>();
-  private final SkyframeActionExecutor skyframeActionExecutor;
+  protected final SkyframeActionExecutor skyframeActionExecutor;
   private ActionExecutionFunction actionExecutionFunction;
   protected SkyframeProgressReceiver progressReceiver;
   private final AtomicReference<CyclesReporter> cyclesReporter = new AtomicReference<>();
@@ -398,8 +398,7 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
       MutableArtifactFactorySupplier artifactResolverSupplier,
       @Nullable ConfiguredTargetProgressReceiver configuredTargetProgress,
       @Nullable NonexistentFileReceiver nonexistentFileReceiver,
-      @Nullable ManagedDirectoriesKnowledge managedDirectoriesKnowledge,
-      NestedSetExpander nestedSetExpander) {
+      @Nullable ManagedDirectoriesKnowledge managedDirectoriesKnowledge) {
     // Strictly speaking, these arguments are not required for initialization, but all current
     // callsites have them at hand, so we might as well set them during construction.
     this.skyframeExecutorConsumerOnInit = skyframeExecutorConsumerOnInit;
@@ -429,11 +428,7 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     this.defaultBuildOptions = defaultBuildOptions;
     this.skyframeActionExecutor =
         new SkyframeActionExecutor(
-            actionKeyContext,
-            statusReporterRef,
-            this::getPathEntries,
-            this::createSourceArtifact,
-            nestedSetExpander);
+            actionKeyContext, statusReporterRef, this::getPathEntries, this::createSourceArtifact);
     this.skyframeBuildView =
         new SkyframeBuildView(
             directories,
@@ -678,7 +673,7 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
 
   public void configureActionExecutor(
       MetadataProvider fileCache, ActionInputPrefetcher actionInputPrefetcher) {
-    this.skyframeActionExecutor.configure(fileCache, actionInputPrefetcher);
+    skyframeActionExecutor.configure(fileCache, actionInputPrefetcher, NestedSetExpander.DEFAULT);
   }
 
   public void dump(boolean summarize, PrintStream out) {

--- a/src/test/java/com/google/devtools/build/lib/skyframe/TimestampBuilderTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/TimestampBuilderTestCase.java
@@ -220,8 +220,7 @@ public abstract class TimestampBuilderTestCase extends FoundationTestCase {
             actionKeyContext,
             new AtomicReference<>(statusReporter),
             /*sourceRootSupplier=*/ () -> ImmutableList.of(),
-            /*sourceArtifactFactory=*/ unused -> null,
-            NestedSetExpander.DEFAULT);
+            /*sourceArtifactFactory=*/ unused -> null);
 
     Path actionOutputBase = scratch.dir("/usr/local/google/_blaze_jrluser/FAKEMD5/action_out/");
     skyframeActionExecutor.setActionLogBufferPathGenerator(
@@ -229,7 +228,7 @@ public abstract class TimestampBuilderTestCase extends FoundationTestCase {
 
     MetadataProvider cache =
         new SingleBuildFileCache(rootDirectory.getPathString(), scratch.getFileSystem());
-    skyframeActionExecutor.configure(cache, ActionInputPrefetcher.NONE);
+    skyframeActionExecutor.configure(cache, ActionInputPrefetcher.NONE, NestedSetExpander.DEFAULT);
 
     final InMemoryMemoizingEvaluator evaluator =
         new InMemoryMemoizingEvaluator(


### PR DESCRIPTION
NestedSetExpander is now permitted to throw TimeoutException, which it may wish to do if the NestedSet is from remote storage and is not available within a certain threshold. In this case, CppCompileAction will treat this dependency's primary output as a lost input, along with any other dependencies with still-pending NestedSets. Rewinding will allow us to rebuild the nodes with the missing NestedSets.

To facilitate setting a custom NestedSetExpander in tests, it is now set in SkyframeActionExecutor#configure instead of passed into the constructor.

PiperOrigin-RevId: 301382884