### PR TITLE
Slightly improve debugging message when artifact's generating action …

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/ArtifactFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ArtifactFunction.java
@@ -30,7 +30,6 @@ import com.google.devtools.build.lib.actions.Artifact.DerivedArtifact;
 import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
 import com.google.devtools.build.lib.actions.ArtifactOwner;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
-import com.google.devtools.build.lib.actions.FileStateType;
 import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.actions.FilesetTraversalParams.DirectTraversalRoot;
 import com.google.devtools.build.lib.actions.FilesetTraversalParams.PackageBoundaryMode;
@@ -55,10 +54,10 @@ import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 /**
- * A builder of values for {@link ArtifactSkyKey} keys when the key is not a simple generated
- * artifact. To save memory, ordinary generated artifacts (non-middleman, non-tree) have their
- * metadata accessed directly from the corresponding {@link ActionExecutionValue}. This SkyFunction
- * is therefore only usable for source, middleman, and tree artifacts.
+ * A builder of values for {@link Artifact} keys when the key is not a simple generated artifact. To
+ * save memory, ordinary generated artifacts (non-middleman, non-tree) have their metadata accessed
+ * directly from the corresponding {@link ActionExecutionValue}. This SkyFunction is therefore only
+ * usable for source, middleman, and tree artifacts.
  */
 class ArtifactFunction implements SkyFunction {
   private final Supplier<Boolean> mkdirForTreeArtifacts;
@@ -290,23 +289,12 @@ class ArtifactFunction implements SkyFunction {
       Artifact.DerivedArtifact artifact, ActionExecutionValue actionValue) {
     Preconditions.checkState(!artifact.isMiddlemanArtifact(), "%s %s", artifact, actionValue);
     Preconditions.checkState(!artifact.isTreeArtifact(), "%s %s", artifact, actionValue);
-    FileArtifactValue value = actionValue.getArtifactValue(artifact);
-    if (value != null) {
-      return value;
-    }
-    FileArtifactValue data =
-        Preconditions.checkNotNull(
-            actionValue.getArtifactValue(artifact), "%s %s", artifact, actionValue);
-    Preconditions.checkNotNull(
-        data.getDigest(), "Digest should already have been calculated for %s (%s)", artifact, data);
-    // Directories are special-cased because their mtimes are used, so should have been constructed
-    // during execution of the action (in ActionMetadataHandler#maybeStoreAdditionalData).
-    Preconditions.checkState(
-        data.getType() == FileStateType.REGULAR_FILE || data.getType() == FileStateType.SYMLINK,
-        "Should be file or symlink %s (%s)",
+    return Preconditions.checkNotNull(
+        actionValue.getArtifactValue(artifact),
+        "%s %s %s",
         artifact,
-        data);
-    return data;
+        artifact.getGeneratingActionKey(),
+        actionValue);
   }
 
   @Nullable


### PR DESCRIPTION
…value does not contain metadata for it: show the key of the value. Also clean up some dead code after https://github.com/bazelbuild/bazel/commit/c35878a258d3c8a5305389aadd17ac0049defa15: the "data"-specific checks are no longer relevant, since there's a unified codepath for artifact metadata.

PiperOrigin-RevId: 302348299