### PR TITLE
Change getNumberOfDirectDepGroups to hasAtLeastOneDep.

### DIFF
--- a/src/main/java/com/google/devtools/build/skyframe/DelegatingNodeEntry.java
+++ b/src/main/java/com/google/devtools/build/skyframe/DelegatingNodeEntry.java
@@ -162,8 +162,8 @@ public abstract class DelegatingNodeEntry implements NodeEntry {
   }
 
   @Override
-  public int getNumberOfDirectDepGroups() throws InterruptedException {
-    return getDelegate().getNumberOfDirectDepGroups();
+  public boolean hasAtLeastOneDep() throws InterruptedException {
+    return getDelegate().hasAtLeastOneDep();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/skyframe/InMemoryMemoizingEvaluator.java
+++ b/src/main/java/com/google/devtools/build/skyframe/InMemoryMemoizingEvaluator.java
@@ -228,7 +228,7 @@ public final class InMemoryMemoizingEvaluator implements MemoizingEvaluator {
       if (prevEntry != null && prevEntry.isDone()) {
         if (keepEdges) {
           try {
-            if (prevEntry.getNumberOfDirectDepGroups() == 0) {
+            if (!prevEntry.hasAtLeastOneDep()) {
               if (newValue.equals(prevEntry.getValue())
                   && !valuesToDirty.contains(key)
                   && !valuesToDelete.contains(key)) {

--- a/src/main/java/com/google/devtools/build/skyframe/InMemoryNodeEntry.java
+++ b/src/main/java/com/google/devtools/build/skyframe/InMemoryNodeEntry.java
@@ -211,8 +211,8 @@ public class InMemoryNodeEntry implements NodeEntry {
   }
 
   @Override
-  public int getNumberOfDirectDepGroups() {
-    return GroupedList.numGroups(getCompressedDirectDepsForDoneEntry());
+  public boolean hasAtLeastOneDep() {
+    return GroupedList.numGroups(getCompressedDirectDepsForDoneEntry()) > 0;
   }
 
   /** Returns the compressed {@link GroupedList} of direct deps. Can only be called when done. */

--- a/src/main/java/com/google/devtools/build/skyframe/NodeEntry.java
+++ b/src/main/java/com/google/devtools/build/skyframe/NodeEntry.java
@@ -108,14 +108,14 @@ public interface NodeEntry extends ThinNodeEntry {
   Iterable<SkyKey> getDirectDeps() throws InterruptedException;
 
   /**
-   * Returns the number of groups in this node's direct deps.
+   * Returns {@code true} if this node has at least one direct dep.
    *
    * <p>Prefer calling this over {@link #getDirectDeps} if possible.
    *
    * <p>This method may only be called after the evaluation of this node is complete.
    */
   @ThreadSafe
-  int getNumberOfDirectDepGroups() throws InterruptedException;
+  boolean hasAtLeastOneDep() throws InterruptedException;
 
   /** Removes a reverse dependency. */
   @ThreadSafe

--- a/src/test/java/com/google/devtools/build/skyframe/InMemoryNodeEntryTest.java
+++ b/src/test/java/com/google/devtools/build/skyframe/InMemoryNodeEntryTest.java
@@ -847,7 +847,6 @@ public class InMemoryNodeEntryTest {
       }
     }
     entry.setValue(new IntegerValue(42), IntVersion.of(42L));
-    assertThat(entry.getNumberOfDirectDepGroups()).isEqualTo(groupedDirectDeps.size());
     int i = 0;
     GroupedList<SkyKey> entryGroupedDirectDeps =
         GroupedList.create(entry.getCompressedDirectDepsForDoneEntry());
@@ -855,6 +854,32 @@ public class InMemoryNodeEntryTest {
     for (Iterable<SkyKey> depGroup : entryGroupedDirectDeps) {
       assertThat(depGroup).containsExactlyElementsIn(groupedDirectDeps.get(i++));
     }
+  }
+
+  @Test
+  public void hasAtLeastOneDep_true() throws Exception {
+    SkyKey dep = key("dep");
+    InMemoryNodeEntry entry = new InMemoryNodeEntry();
+    assertThatNodeEntry(entry)
+        .addReverseDepAndCheckIfDone(null)
+        .isEqualTo(DependencyState.NEEDS_SCHEDULING);
+    entry.markRebuilding();
+    entry.addTemporaryDirectDeps(GroupedListHelper.create(dep));
+    entry.signalDep(ZERO_VERSION, dep);
+    entry.setValue(new IntegerValue(1), ZERO_VERSION);
+    assertThat(entry.hasAtLeastOneDep()).isTrue();
+  }
+
+  @Test
+  public void hasAtLeastOneDep_false() throws Exception {
+    InMemoryNodeEntry entry = new InMemoryNodeEntry();
+    assertThatNodeEntry(entry)
+        .addReverseDepAndCheckIfDone(null)
+        .isEqualTo(DependencyState.NEEDS_SCHEDULING);
+    entry.markRebuilding();
+    entry.addTemporaryDirectDeps(new GroupedListHelper<>());
+    entry.setValue(new IntegerValue(1), ZERO_VERSION);
+    assertThat(entry.hasAtLeastOneDep()).isFalse();
   }
 
   private static Set<SkyKey> setValue(


### PR DESCRIPTION
The only callers of this method simply care whether the node has any deps. Changing the return type to a boolean allows implementations to more efficiently respond without counting the number of dep groups.

PiperOrigin-RevId: 307286609